### PR TITLE
Hopefully fixing Markdowns

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -31,7 +31,7 @@
         "Lesson3/3.1/3.1.md",
         "Lesson3/3.1/3.01.md",
         "Lesson3/3.2/3.2.md",
-        "Lesson3/3.1/3.2.1.md",
+        "Lesson3/3.2/3.2.1.md",
         "Lesson3/3.1/3.1.2.md",
         "Lesson3/3.3/3.3.md",
         "Lesson3/3.3/3.3.1.md",

--- a/pxt.json
+++ b/pxt.json
@@ -72,7 +72,7 @@
         "test.ts"
     ],
     "targetVersions": {
-        "target": "1.7.6",
+        "target": "1.7.10",
         "targetId": "minecraft"
     },
     "supportedTargets": [


### PR DESCRIPTION
It seems that Lesson3/3.2/3.2.1 was correct in the PXT.json but was located at Lesson3/3.1/3.2.1 (i.e. 3.2.1 was in the 3.1 folder instead of the 3.2 folder). Fixing that made it work from my repo.

I also bumped the version to 1.7.10 (which is the latest version). It's not super critical, but was required for me to be able to test this with the MakeCode github client.